### PR TITLE
Improvement/roslaunch commandline arguments

### DIFF
--- a/march_ws/src/march_control/src/control_node/main.cpp
+++ b/march_ws/src/march_control/src/control_node/main.cpp
@@ -22,7 +22,7 @@ void gaitInputCallback(const march_custom_msgs::GaitStatus msg)
 std_msgs::Float64 createMsg(float data)
 {
   std_msgs::Float64 msg;
-  msg.data = data*1;
+  msg.data = data * 1;
   return msg;
 }
 
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
       std::vector<std::string> strs;
       boost::split(strs, line, boost::is_any_of("~"));
 
-//      ROS_INFO_STREAM(stof(strs.at(0)));
+      //      ROS_INFO_STREAM(stof(strs.at(0)));
 
       left_hip_position_pub.publish(createMsg(stof(strs.at(0))));
       left_knee_position_pub.publish(createMsg(stof(strs.at(1))));
@@ -76,8 +76,17 @@ int main(int argc, char** argv)
       right_hip_position_pub.publish(createMsg(stof(strs.at(3))));
       right_knee_position_pub.publish(createMsg(stof(strs.at(4))));
       right_ankle_position_pub.publish(createMsg(stof(strs.at(5))));
-
+    }
+    else
+    {
       counter += 0.01;
+
+      left_hip_position_pub.publish(createMsg(std::sin(counter)));
+      left_knee_position_pub.publish(createMsg(std::sin(counter)));
+      left_ankle_position_pub.publish(createMsg(std::sin(counter)));
+      right_hip_position_pub.publish(createMsg(std::cos(counter)));
+      right_knee_position_pub.publish(createMsg(std::cos(counter)));
+      right_ankle_position_pub.publish(createMsg(std::cos(counter)));
     }
   }
 

--- a/march_ws/src/march_description/urdf/march.xacro
+++ b/march_ws/src/march_description/urdf/march.xacro
@@ -5,12 +5,12 @@
     <!-- Constants for robot dimensions -->
     <xacro:property name="PI" value="3.1415926535897931"/>
     <xacro:property name="mass" value="1"/> <!-- arbitrary value for mass -->
-    <xacro:property name="width" value="0.1"/> <!-- Square dimensions (widthxwidth) of beams -->
+    <xacro:property name="width" value="0.05"/> <!-- Square dimensions (widthxwidth) of beams -->
 
-    <xacro:property name="upper_leg_height" value="${0.37*3}"/>
-    <xacro:property name="lower_leg_height" value="${0.41*3}"/>
-    <xacro:property name="foot_height" value="${0.14*3}"/>
-    <xacro:property name="hip_height" value="1"/>
+    <xacro:property name="upper_leg_height" value="${0.37*1}"/>
+    <xacro:property name="lower_leg_height" value="${0.41*1}"/>
+    <xacro:property name="foot_height" value="${0.14*1}"/>
+    <xacro:property name="hip_height" value="0.3"/>
 
     <xacro:property name="hip_rotation_lower_limit" value="${-100*pi/180}"/>
     <xacro:property name="hip_rotation_upper_limit" value="${90*pi/180}"/>

--- a/march_ws/src/march_main/launch/main.launch
+++ b/march_ws/src/march_main/launch/main.launch
@@ -1,17 +1,28 @@
 <launch>
 
+    <arg name="simulation" default="true" doc="Launch the simulation or the actual exoskeleton"/>
+
+    <arg name="rqt" default="false" doc="Launch the rqt nodes"/>
+    <arg name="rviz" default="true" doc="Launch rviz"/>
+    <arg name="gazebo_ui" default="true" doc="Launch Gazebo with a ui"/>
 
     <!-- Load the URDF of the exoskeleton in the ROS parameter server.-->
     <include file="$(find march_description)/launch/load_description.launch"/>
 
     <!-- OPTIONAL: Launch the rqt plugins that allow for easy debugging.-->
-    <!--<include file="$(find march_main)/launch/rqt.launch"/>-->
+    <group if="$(arg rqt)">
+        <include file="$(find march_main)/launch/rqt.launch"/>
+    </group>
 
     <!-- OPTIONAL: Load the rviz plugin which visualizes the actual position of the exoskeleton.-->
-    <node name="rviz" pkg="rviz" type="rviz"/>
+    <group if="$(arg rviz)">
+        <node name="rviz" pkg="rviz" type="rviz"/>
+    </group>
 
     <!-- Launch the gazebo simulation.-->
-    <include file="$(find march_gazebo)/launch/march_world.launch"/>
+    <include file="$(find march_gazebo)/launch/march_world.launch">
+        <arg name="gui" value="$(arg gazebo_ui)"/>
+    </include>
 
     <!-- Launch the control node.-->
     <include file="$(find march_control)/launch/march_control.launch"/>


### PR DESCRIPTION
## Issues
Closes #50 

## Description
It is now possible to pass commandline arguments to the launchfile like

```
roslaunch march_main main.launch rqt:=false rviz:=true gazebo_ui:=false
```

pay special attention to `march_main main.launch::24` and `march_gazebo march march_world.launch`. It contains an example of how to properly nest launch parameters.

## Features
- Document on wiki how to view available commands
- Implement commandline arguments in launchfiles
- Implement commandline arguments being passed to nested launchfiles

## Documentation
- Created https://github.com/project-march/march-iv/wiki/Configuring-the-launchfile
- Updated the bottom of https://github.com/project-march/march-iv/wiki/Launching-the-exoskeleton