### PR TITLE
add dynamic reconfigure for the gait succeeded offset

### DIFF
--- a/march_gait_scheduler/CMakeLists.txt
+++ b/march_gait_scheduler/CMakeLists.txt
@@ -3,6 +3,7 @@ project(march_gait_scheduler)
 add_definitions(-std=c++11 -Wall -g)
 
 find_package(catkin REQUIRED COMPONENTS
+        dynamic_reconfigure
         code_coverage
         actionlib
         actionlib_msgs
@@ -13,6 +14,10 @@ find_package(catkin REQUIRED COMPONENTS
         rostest
         trajectory_msgs
         )
+
+generate_dynamic_reconfigure_options(
+        config/Scheduler.cfg
+)
 
 catkin_package(
         INCLUDE_DIRS include
@@ -44,7 +49,7 @@ target_link_libraries(march_gait_scheduler ${catkin_LIBRARIES})
 add_executable(gait_scheduler_node src/GaitSchedulerNode.cpp)
 
 target_link_libraries(gait_scheduler_node march_gait_scheduler)
-add_dependencies(gait_scheduler_node ${catkin_EXPORTED_TARGETS})
+add_dependencies(gait_scheduler_node ${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 
 ## Add gtest based cpp test target and link libraries
 if (CATKIN_ENABLE_TESTING)

--- a/march_gait_scheduler/config/Scheduler.cfg
+++ b/march_gait_scheduler/config/Scheduler.cfg
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+PACKAGE = "march_gait_scheduler"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# Default values of 1 overwritten by march_fake_sensor_data.launch.
+gen.add("gait_succeeded_offset",    double_t,    0, "The offset time for the scheduler to return succeeded", 0.2,  0, 2)
+
+exit(gen.generate(PACKAGE, "march_gait_scheduler", "Scheduler"))

--- a/march_gait_scheduler/include/march_gait_scheduler/Scheduler.h
+++ b/march_gait_scheduler/include/march_gait_scheduler/Scheduler.h
@@ -8,6 +8,8 @@
 #include <ros/ros.h>
 #include <trajectory_msgs/JointTrajectory.h>
 
+#include <march_gait_scheduler/SchedulerConfig.h>
+
 class Scheduler
 {
   const march_shared_resources::GaitGoal* lastGaitGoal = nullptr;
@@ -23,7 +25,7 @@ public:
    */
   ros::Duration GAIT_SUCCEEDED_OFFSET = ros::Duration(0.2);
   ros::Time getEndTimeCurrentGait();
-  control_msgs::FollowJointTrajectoryGoal scheduleGait(const march_shared_resources::GaitGoal *gaitGoal,
+  control_msgs::FollowJointTrajectoryGoal scheduleGait(const march_shared_resources::GaitGoal* gaitGoal,
                                                        ros::Duration offset);
 };
 

--- a/march_gait_scheduler/package.xml
+++ b/march_gait_scheduler/package.xml
@@ -12,6 +12,7 @@
     <build_depend>actionlib_msgs</build_depend>
     <build_depend>code_coverage</build_depend>
     <build_depend>control_msgs</build_depend>
+    <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>march_shared_resources</build_depend>
     <build_depend>roslint</build_depend>
     <build_depend>roscpp</build_depend>

--- a/march_gait_scheduler/src/Scheduler.cpp
+++ b/march_gait_scheduler/src/Scheduler.cpp
@@ -56,7 +56,7 @@ bool Scheduler::lastScheduledGaitNotStarted()
   return ros::Time::now() < this->startLastGait;
 }
 
-control_msgs::FollowJointTrajectoryGoal Scheduler::scheduleGait(const march_shared_resources::GaitGoal *gaitGoal,
+control_msgs::FollowJointTrajectoryGoal Scheduler::scheduleGait(const march_shared_resources::GaitGoal* gaitGoal,
                                                                 ros::Duration offset)
 {
   ROS_DEBUG("Start time last gait: %f", this->startLastGait.toSec());


### PR DESCRIPTION
By adding gait_succeeded_offset to dynamic reconfigure we can now change this value during run-time.
This can be done by running `rosrun rqt_reconfigure rqt_reconfigure` during run time. In this UI you can change the value between 0 (no offset at all) up to 2 seconds. We see that around 0.2 seconds offset the joint trajectory will drop the first point, because the trajectory is received too late.

To understand how the config file works read this: http://wiki.ros.org/dynamic_reconfigure/Tutorials/HowToWriteYourFirstCfgFile