### PR TITLE
Throw a better error when rqt_gait_selection can't connect to services

### DIFF
--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection.py
@@ -45,13 +45,19 @@ class GaitSelectionPlugin(Plugin):
             print 'unknowns: ', unknowns
 
         # Connect to services
-        rospy.wait_for_service('/march/gait_selection/get_version_map', 3)
+        try:
+            rospy.wait_for_service('/march/gait_selection/get_version_map', 3)
+            rospy.wait_for_service('/march/gait_selection/get_directory_structure', 3)
+            rospy.wait_for_service('/march/gait_selection/set_version_map', 3)
+            rospy.wait_for_service('/march/gait_selection/update_default_versions', 3)
+        except rospy.ROSException:
+            rospy.logerr("Shutting down march_rqt_gait_selection, could not connect to march_gait_selection.")
+            rospy.signal_shutdown("Shutting down march_rqt_gait_selection, could not connect to march_gait_selection.")
+            exit(0)
+
         self.get_version_map = rospy.ServiceProxy('/march/gait_selection/get_version_map', Trigger)
-        rospy.wait_for_service('/march/gait_selection/get_directory_structure', 3)
         self.get_directory_structure = rospy.ServiceProxy('/march/gait_selection/get_directory_structure', Trigger)
-        rospy.wait_for_service('/march/gait_selection/set_version_map', 3)
         self.set_version_map = rospy.ServiceProxy('/march/gait_selection/set_version_map', StringTrigger)
-        rospy.wait_for_service('/march/gait_selection/update_default_versions', 3)
         self.update_default_versions = rospy.ServiceProxy('/march/gait_selection/update_default_versions', Trigger)
 
         # Create QWidget


### PR DESCRIPTION
Before
```
process[rosout-1]: started with pid [15967]
started core service [/rosout]
process[march_rqt_gait_selection-2]: started with pid [15975]
arguments:  Namespace(quiet=False)
unknowns:  []
PluginManager._load_plugin() could not load plugin "march_rqt_gait_selection/GaitSelectionPlugin":
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/plugin_handler.py", line 99, in load
    self._load()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/plugin_handler_direct.py", line 54, in _load
    self._plugin = self._plugin_provider.load(self._instance_id.plugin_id, self._context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_gui_py/ros_py_plugin_provider.py", line 60, in load
    return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/qt_gui/composite_plugin_provider.py", line 71, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rqt_gui/ros_plugin_provider.py", line 101, in load
    return class_ref(plugin_context)
  File "/home/march/march_ws/src/march-iv/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection.py", line 48, in __init__
    rospy.wait_for_service('/march/gait_selection/get_version_map', 3)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 143, in wait_for_service
    raise ROSException("timeout exceeded while waiting for service %s"%resolved_name)
ROSException: timeout exceeded while waiting for service /march/gait_selection/get_version_map

[march_rqt_gait_selection-2] process has died [pid 15975, exit code 1, cmd /home/march/march_ws/src/march-iv/march_rqt_gait_selection/scripts/rqt_gait_selection __name:=march_rqt_gait_selection __log:=/home/march/.ros/log/13e626c8-9339-11e9-bf37-a4badbf06f2e/march_rqt_gait_selection-2.log].
log file: /home/march/.ros/log/13e626c8-9339-11e9-bf37-a4badbf06f2e/march_rqt_gait_selection-2*.log
```

After
```
process[rosout-1]: started with pid [14176]
started core service [/rosout]
process[march_rqt_gait_selection-2]: started with pid [14186]
arguments:  Namespace(quiet=False)
unknowns:  []
[ERROR] [1561023210.743225]: Shutting down march_rqt_gait_selection, could not connect to march_gait_selection.
[march_rqt_gait_selection-2] process has finished cleanly
log file: /home/ishadijcks/.ros/log/73603472-933e-11e9-91d0-f816544b5834/march_rqt_gait_selection-2*.log
```