### PR TITLE
Fix the wrong error messages being published by the rqt_input_device

### DIFF
--- a/march_rqt_input_device/src/march_rqt_input_device/input_device.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device.py
@@ -149,7 +149,7 @@ class InputDevicePlugin(Plugin):
 
     def publish_error(self):
         rospy.logdebug("Mock Input Device published error")
-        self.error_pub.publish(Error(-1, "Fake error thrown by the develop input device.", Error.FATAL))
+        self.error_pub.publish(Error("Fake error thrown by the develop input device.", Error.FATAL))
 
     def publish_alive_msg(self):
         rate = rospy.Rate(20)


### PR DESCRIPTION
Closes #256 

It seems like the message was changed while the rqt_input_device was not updated.