### PR TITLE
Fix limits of test joint in URDF(adjusted for limit switches)

### DIFF
--- a/march_description/urdf/test-joint.xacro
+++ b/march_description/urdf/test-joint.xacro
@@ -15,9 +15,9 @@
     <xacro:property name="bar_mass" value="1.080"/>
     <xacro:property name="bar_width" value="0.05"/>
 
-    <xacro:property name="joint_buffer" value="${5*pi/180}"/> <!-- rad -->
-    <xacro:property name="joint_lower_limit" value="-0.04"/> <!-- rad -->
-    <xacro:property name="joint_upper_limit" value="1.75"/> <!-- rad -->
+    <xacro:property name="joint_buffer" value="${3*pi/180}"/> <!-- rad -->
+    <xacro:property name="joint_lower_limit" value="-0.5673"/> <!-- rad -->
+    <xacro:property name="joint_upper_limit" value="0.3549"/> <!-- rad -->
     <xacro:property name="joint_effort_limit" value="1000.0"/>
     <xacro:property name="joint_velocity_limit" value="1.5"/> <!-- rad/s -->
 


### PR DESCRIPTION
## Description

Adjust the joint lower and upper limit in the urdf, so that they work with the limit switches and the newly defined zeroposition in the testsetup.yaml.
The buffer is 3 degrees. Since we do not need a 5 degree margin between the limit switches and the softlimits.