### PR TITLE
Refactor threading from python to Qt

### DIFF
--- a/march_rqt_input_device/src/march_rqt_input_device/PublishAliveThread.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/PublishAliveThread.py
@@ -1,0 +1,26 @@
+import rospy
+from pyqtgraph.Qt import QtCore
+
+from std_msgs.msg import Time
+
+
+class PublishAliveThread(QtCore.QThread):
+
+    def __init__(self):
+        QtCore.QThread.__init__(self)
+        self.allowed_to_run = True
+        self.alive_pub = rospy.Publisher(
+            'march/input_device/alive', Time, queue_size=10)
+
+    def run(self):
+        rate = rospy.Rate(20)
+        while self.allowed_to_run:
+            try:
+                rate.sleep()
+            except rospy.exceptions.ROSInterruptException:
+                self.allowed_to_run = False
+
+            self.alive_pub.publish(Time(rospy.Time.now()))
+
+    def stop(self):
+        self.allowed_to_run = False

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device.py
@@ -9,11 +9,11 @@ from python_qt_binding.QtCore import QSize
 from python_qt_binding.QtWidgets import QWidget
 from march_shared_resources.msg import Error
 from march_shared_resources.msg import GaitInstruction
-from std_msgs.msg import Time
 
 from march_rqt_input_device.MarchButton import MarchButton
 from march_rqt_input_device.LayoutBuilder import LayoutBuilder
 
+from march_rqt_input_device.PublishAliveThread import PublishAliveThread
 
 class InputDevicePlugin(Plugin):
 
@@ -115,23 +115,13 @@ class InputDevicePlugin(Plugin):
         self.instruction_gait_pub = rospy.Publisher(
             'march/input_device/instruction', GaitInstruction, queue_size=10)
 
-        self.alive_pub = rospy.Publisher(
-            'march/input_device/alive', Time, queue_size=10)
-
         self.error_pub = rospy.Publisher('march/error', Error, queue_size=10)
 
-        self.publish_alive = True
-
-        self.pub_thread = threading.Thread(target=self.publish_alive_msg)
-        self.pub_thread.start()
+        self.alive_thread = PublishAliveThread()
+        self.alive_thread.start()
 
     def shutdown_plugin(self):
-        # unregister all publishers here
-        self.publish_alive = False
-        self.pub_thread.join()
-        self.instruction_gait_pub.unregister()
-        self.error_pub.unregister()
-        self.alive_pub.unregister()
+        self.alive_thread.stop()
 
     def save_settings(self, plugin_settings, instance_settings):
         # TODO save intrinsic configuration, usually using:
@@ -162,16 +152,6 @@ class InputDevicePlugin(Plugin):
     def publish_error(self):
         rospy.logdebug("Mock Input Device published error")
         self.error_pub.publish(Error("Fake error thrown by the develop input device.", Error.FATAL))
-
-    def publish_alive_msg(self):
-        rate = rospy.Rate(20)
-        while not rospy.is_shutdown() and self.publish_alive:
-            try:
-                rate.sleep()
-            except rospy.exceptions.ROSInterruptException:
-                self.publish_alive = False
-
-            self.alive_pub.publish(Time(rospy.Time.now()))
 
     # def trigger_configuration(self):
     # Comment in to signal that the plugin has a way to configure


### PR DESCRIPTION
Previously the rqt_input_device would freeze when stopping it with Ctrl+C, and throw 2 warnings when unregistering them. Now it no longer throws the warning and prevent freezing by closing the thread properly

Closes #273
