### PR TITLE
add margin for time offset between arduino and master pc

### DIFF
--- a/march_safety/src/InputDeviceSafety.cpp
+++ b/march_safety/src/InputDeviceSafety.cpp
@@ -49,7 +49,7 @@ void InputDeviceSafety::update()
     }
     // Check if the alive msg is not timestamped with a future time.
     // This can happen when one node is using sim_tim and others aren't.
-    // Add 1 second extra margin for stamp offset between board and PC
+    // Add small margin to take the stamp offset between board and PC into account
     if (ros::Time::now() + ros::Duration(0.02) < time_last_alive)
     {
       std::ostringstream message_stream;

--- a/march_safety/src/InputDeviceSafety.cpp
+++ b/march_safety/src/InputDeviceSafety.cpp
@@ -50,7 +50,7 @@ void InputDeviceSafety::update()
     // Check if the alive msg is not timestamped with a future time.
     // This can happen when one node is using sim_tim and others aren't.
     // Add 1 second extra margin for stamp offset between board and PC
-    if (ros::Time::now() + ros::Duration(0.01) < time_last_alive)
+    if (ros::Time::now() + ros::Duration(0.02) < time_last_alive)
     {
       std::ostringstream message_stream;
       message_stream << "Input Device Connection message is from the future. Current time: " << ros::Time::now().toSec()

--- a/march_safety/src/InputDeviceSafety.cpp
+++ b/march_safety/src/InputDeviceSafety.cpp
@@ -50,7 +50,7 @@ void InputDeviceSafety::update()
     // Check if the alive msg is not timestamped with a future time.
     // This can happen when one node is using sim_tim and others aren't.
     // Add 1 second extra margin for stamp offset between board and PC
-    if (ros::Time::now() + ros::Duration(1) < time_last_alive)
+    if (ros::Time::now() + ros::Duration(0.01) < time_last_alive)
     {
       std::ostringstream message_stream;
       message_stream << "Input Device Connection message is from the future. Current time: " << ros::Time::now().toSec()

--- a/march_safety/src/InputDeviceSafety.cpp
+++ b/march_safety/src/InputDeviceSafety.cpp
@@ -49,7 +49,8 @@ void InputDeviceSafety::update()
     }
     // Check if the alive msg is not timestamped with a future time.
     // This can happen when one node is using sim_tim and others aren't.
-    if (ros::Time::now() < time_last_alive)
+    // Add 1 second extra margin for stamp offset between board and PC
+    if (ros::Time::now() + ros::Duration(1) < time_last_alive)
     {
       std::ostringstream message_stream;
       message_stream << "Input Device Connection message is from the future. Current time: " << ros::Time::now().toSec()

--- a/march_safety/test/march_safety_connection.test
+++ b/march_safety/test/march_safety_connection.test
@@ -5,7 +5,7 @@
 
     <node name="march_safety_node" pkg="march_safety" type="march_safety_node" output="screen">
         <rosparam>
-            input_device_connection_timeout: 100
+            input_device_connection_timeout: 1000
             send_errors_interval: 1000
         </rosparam>
     </node>


### PR DESCRIPTION
I noticed a offset between the time on the arduino and on the master pc.
I also found some open issues on time sync: https://github.com/ros-drivers/rosserial/issues/392
- [x] For now I just added a small margin.
- [x] Increased the input_device_connection_timeout in the tests, to make it more stable.
