### PR TITLE
make the safety node required

### DIFF
--- a/march_safety/launch/march_safety.launch
+++ b/march_safety/launch/march_safety.launch
@@ -1,6 +1,6 @@
 <launch>
 
-    <node name="march_safety_node" pkg="march_safety" type="march_safety_node" output="screen">
+    <node name="march_safety_node" pkg="march_safety" type="march_safety_node" output="screen" required="true">
         <rosparam>
             default_temperature_threshold: 40
             input_device_connection_timeout: 1000


### PR DESCRIPTION
Make the safety node required.
"If node dies, kill entire roslaunch." - AdamAllevato [1]

[1] http://wiki.ros.org/roslaunch/XML/node