### PR TITLE
Seperate tests to avoid safety tests interfering with each other

### DIFF
--- a/march_safety/CMakeLists.txt
+++ b/march_safety/CMakeLists.txt
@@ -65,11 +65,23 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} march_safety gtest gmock)
 
 
-    add_rostest_gtest(${PROJECT_NAME}-test-connection
-            test/march_safety_connection.test
-            test/TestConnectionLostError.cpp
+    add_rostest_gtest(${PROJECT_NAME}-test-connection-lost
+            test/march_safety_connection_lost.test
+            test/TestConnectionLost.cpp
             )
-    target_link_libraries(${PROJECT_NAME}-test-connection ${catkin_LIBRARIES} march_safety gtest gmock)
+
+    add_rostest_gtest(${PROJECT_NAME}-test-connection-never-started
+            test/march_safety_connection_never_started.test
+            test/TestConnectionNeverStarted.cpp
+            )
+
+    add_rostest_gtest(${PROJECT_NAME}-test-connection-not-lost
+            test/march_safety_connection_not_lost.test
+            test/TestConnectionNotLost.cpp
+            )
+    target_link_libraries(${PROJECT_NAME}-test-connection-lost ${catkin_LIBRARIES} march_safety gtest gmock)
+    target_link_libraries(${PROJECT_NAME}-test-connection-never-started ${catkin_LIBRARIES} march_safety gtest gmock)
+    target_link_libraries(${PROJECT_NAME}-test-connection-not-lost ${catkin_LIBRARIES} march_safety gtest gmock)
 
     if(ENABLE_COVERAGE_TESTING)
         set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")

--- a/march_safety/test/TestConnectionLost.cpp
+++ b/march_safety/test/TestConnectionLost.cpp
@@ -9,57 +9,12 @@
 #include <march_safety/TemperatureSafety.h>
 #include "ErrorCounter.cpp"
 
-class TestConnectionLostError : public ::testing::Test
+class TestConnectionLost : public ::testing::Test
 {
 protected:
 };
 
-TEST_F(TestConnectionLostError, connectionNeverStarted)
-{
-  ros::Time::init();
-  ros::NodeHandle nh;
-  ErrorCounter errorCounter;
-  ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
-
-  while (0 == sub.getNumPublishers())
-  {
-    ros::Duration(0.1).sleep();
-  }
-  EXPECT_EQ(1, sub.getNumPublishers());
-
-  ros::spinOnce();
-  ros::Duration(0.5).sleep();
-  ros::spinOnce();
-  EXPECT_EQ(0, errorCounter.count);
-}
-
-TEST_F(TestConnectionLostError, connectionNotLost)
-{
-  ros::Time::init();
-  ros::NodeHandle nh;
-  int send_errors_interval;
-  nh.getParam("/march_safety_node/send_errors_interval", send_errors_interval);
-  ros::Publisher pub_alive = nh.advertise<std_msgs::Time>("march/input_device/alive", 0);
-  ErrorCounter errorCounter;
-  ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
-
-  while (0 == pub_alive.getNumSubscribers() || 0 == sub.getNumPublishers())
-  {
-    ros::Duration(0.1).sleep();
-  }
-  EXPECT_EQ(1, pub_alive.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
-
-  std_msgs::Time timeMessage;
-  timeMessage.data = ros::Time::now();
-  pub_alive.publish(timeMessage);
-  ros::spinOnce();
-  ros::Duration(send_errors_interval / 2 / 1000).sleep();
-  ros::spinOnce();
-  EXPECT_EQ(0, errorCounter.count);
-}
-
-TEST_F(TestConnectionLostError, connectionLost)
+TEST_F(TestConnectionLost, connectionLost)
 {
   ros::Time::init();
   ros::NodeHandle nh;

--- a/march_safety/test/TestConnectionNeverStarted.cpp
+++ b/march_safety/test/TestConnectionNeverStarted.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019 Project March.
+
+#include "gtest/gtest.h"
+#include "ros/ros.h"
+#include <iostream>
+#include <std_msgs/Time.h>
+#include <march_shared_resources/TopicNames.h>
+
+#include <march_safety/TemperatureSafety.h>
+#include "ErrorCounter.cpp"
+
+class TestConnectionNeverStarted : public ::testing::Test
+{
+protected:
+};
+
+TEST_F(TestConnectionNeverStarted, connectionNeverStarted)
+{
+  ros::Time::init();
+  ros::NodeHandle nh;
+  ErrorCounter errorCounter;
+  ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
+
+  while (0 == sub.getNumPublishers())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(1, sub.getNumPublishers());
+
+  ros::spinOnce();
+  ros::Duration(0.5).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(0, errorCounter.count);
+}
+
+/**
+ * The main method which runs all the tests
+ */
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "march_safety_test");
+  testing::InitGoogleTest(&argc, argv);
+  auto res = RUN_ALL_TESTS();
+
+  ros::shutdown();
+  return res;
+}

--- a/march_safety/test/TestConnectionNotLost.cpp
+++ b/march_safety/test/TestConnectionNotLost.cpp
@@ -1,0 +1,54 @@
+// Copyright 2019 Project March.
+
+#include "gtest/gtest.h"
+#include "ros/ros.h"
+#include <iostream>
+#include <std_msgs/Time.h>
+#include <march_shared_resources/TopicNames.h>
+
+#include <march_safety/TemperatureSafety.h>
+#include "ErrorCounter.cpp"
+
+class TestConnectionNotLost : public ::testing::Test
+{
+protected:
+};
+
+TEST_F(TestConnectionNotLost, connectionNotLost)
+{
+  ros::Time::init();
+  ros::NodeHandle nh;
+  int send_errors_interval;
+  nh.getParam("/march_safety_node/send_errors_interval", send_errors_interval);
+  ros::Publisher pub_alive = nh.advertise<std_msgs::Time>("march/input_device/alive", 0);
+  ErrorCounter errorCounter;
+  ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
+
+  while (0 == pub_alive.getNumSubscribers() || 0 == sub.getNumPublishers())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  EXPECT_EQ(1, pub_alive.getNumSubscribers());
+  EXPECT_EQ(1, sub.getNumPublishers());
+
+  std_msgs::Time timeMessage;
+  timeMessage.data = ros::Time::now();
+  pub_alive.publish(timeMessage);
+  ros::spinOnce();
+  ros::Duration(send_errors_interval / 2 / 1000).sleep();
+  ros::spinOnce();
+  EXPECT_EQ(0, errorCounter.count);
+}
+
+/**
+ * The main method which runs all the tests
+ */
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "march_safety_test");
+  testing::InitGoogleTest(&argc, argv);
+  auto res = RUN_ALL_TESTS();
+
+  ros::shutdown();
+  return res;
+}

--- a/march_safety/test/march_safety_connection_lost.test
+++ b/march_safety/test/march_safety_connection_lost.test
@@ -10,5 +10,5 @@
         </rosparam>
     </node>
 
-    <test test-name="march_safety_test" pkg="march_safety" type="march_safety-test-connection"/>
+    <test test-name="march_safety_test" pkg="march_safety" type="march_safety-test-connection-lost"/>
 </launch>

--- a/march_safety/test/march_safety_connection_never_started.test
+++ b/march_safety/test/march_safety_connection_never_started.test
@@ -1,0 +1,14 @@
+<launch>
+    <rosparam>
+        /march/joint_names: [test_joint1, test_joint2, test_joint3]
+    </rosparam>
+
+    <node name="march_safety_node" pkg="march_safety" type="march_safety_node" output="screen">
+        <rosparam>
+            input_device_connection_timeout: 1000
+            send_errors_interval: 1000
+        </rosparam>
+    </node>
+
+    <test test-name="march_safety_test" pkg="march_safety" type="march_safety-test-connection-never-started"/>
+</launch>

--- a/march_safety/test/march_safety_connection_not_lost.test
+++ b/march_safety/test/march_safety_connection_not_lost.test
@@ -1,0 +1,14 @@
+<launch>
+    <rosparam>
+        /march/joint_names: [test_joint1, test_joint2, test_joint3]
+    </rosparam>
+
+    <node name="march_safety_node" pkg="march_safety" type="march_safety_node" output="screen">
+        <rosparam>
+            input_device_connection_timeout: 1000
+            send_errors_interval: 1000
+        </rosparam>
+    </node>
+
+    <test test-name="march_safety_test" pkg="march_safety" type="march_safety-test-connection-not-lost"/>
+</launch>


### PR DESCRIPTION
Split the safety node tests to restart the safety node each time.