### PR TITLE
fix temperature above 2000 bug from the slaves

### DIFF
--- a/march_safety/src/TemperatureSafety.cpp
+++ b/march_safety/src/TemperatureSafety.cpp
@@ -36,7 +36,7 @@ void TemperatureSafety::temperatureCallback(const sensor_msgs::TemperatureConstP
 
   std::string error_message = getErrorMessage(temperature, sensor_name);
 
-  // TODO(Olaf) this is a temporary fix, this should be fixed locally on the slaves ask Electro.
+  // TODO(Olav) this is a temporary fix, this should be fixed locally on the slaves ask Electro.
   if (temperature > 2000)
   {
     ROS_WARN("%s", error_message.c_str());

--- a/march_safety/src/TemperatureSafety.cpp
+++ b/march_safety/src/TemperatureSafety.cpp
@@ -36,6 +36,12 @@ void TemperatureSafety::temperatureCallback(const sensor_msgs::TemperatureConstP
 
   std::string error_message = getErrorMessage(temperature, sensor_name);
 
+  //TODO(Olaf) this is a temporary fix, this should be fixed locally on the slaves ask Electro.
+  if (temperature > 2000){
+    ROS_WARN("%s", error_message.c_str());
+    return;
+  }
+
   // If the threshold is exceeded raise an error
   if (temperature > getThreshold(sensor_name, fatal_temperature_thresholds_map))
   {

--- a/march_safety/src/TemperatureSafety.cpp
+++ b/march_safety/src/TemperatureSafety.cpp
@@ -36,8 +36,9 @@ void TemperatureSafety::temperatureCallback(const sensor_msgs::TemperatureConstP
 
   std::string error_message = getErrorMessage(temperature, sensor_name);
 
-  //TODO(Olaf) this is a temporary fix, this should be fixed locally on the slaves ask Electro.
-  if (temperature > 2000){
+  // TODO(Olaf) this is a temporary fix, this should be fixed locally on the slaves ask Electro.
+  if (temperature > 2000)
+  {
     ROS_WARN("%s", error_message.c_str());
     return;
   }


### PR DESCRIPTION
The temperature slaves sometimes send wrong values (first bit flips). These values are always above 2000 and because values above 2000 never occur we can filter them.