### PR TITLE
Fix program install name

### DIFF
--- a/march_rqt_training_log/CMakeLists.txt
+++ b/march_rqt_training_log/CMakeLists.txt
@@ -19,7 +19,7 @@ install(DIRECTORY resource
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
        )
 
-install(PROGRAMS scripts/rqt_launch_menu
+install(PROGRAMS scripts/march_rqt_training_log
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
        )
 


### PR DESCRIPTION
The program name of the rqt training log plugin was still the old value copy pasted from the launch menu... oops :sweat_smile: Don't know why this worked, but I came across the error when trying out the new colcon build tool.