### PR TITLE
Fix slave_count check not having access to ethercat

### DIFF
--- a/march_launch/launch/checks/slave_count.launch
+++ b/march_launch/launch/checks/slave_count.launch
@@ -1,5 +1,5 @@
 <launch>
     <machine name="march" address="march" user="march" env-loader="/home/march/Documents/march_ws/devel/env.sh"/>
 
-    <node name="slave_count_check" pkg="march_hardware" type="slave_count_check" machine="march"/>
+    <node launch-prefix="ethercat_grant" name="slave_count_check" pkg="march_hardware" type="slave_count_check" machine="march"/>
 </launch>


### PR DESCRIPTION
https://github.com/project-march/hardware-interface/pull/162
The above pr broke the slave_count check as the executable no longer had ethercat access.

This is fixed by adding the `ethercat_grant` to the slave count check node.